### PR TITLE
allow ro_crate

### DIFF
--- a/dataregistry/src/main/java/org/fairdatapipeline/dataregistry/content/RegistryCode_run.java
+++ b/dataregistry/src/main/java/org/fairdatapipeline/dataregistry/content/RegistryCode_run.java
@@ -29,6 +29,8 @@ public class RegistryCode_run extends Registry_Updateable {
 
   @XmlElement private APIURL prov_report;
 
+  @XmlElement private APIURL ro_crate;
+
   /** Empty Constructor. */
   public RegistryCode_run() {
     methods_allowed = List.of("GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS");
@@ -119,6 +121,15 @@ public class RegistryCode_run extends Registry_Updateable {
    */
   public APIURL getProv_report() {
     return this.prov_report;
+  }
+
+  /**
+   * APIURL reference to the ro_crate for this Data product
+   *
+   * @return APIURL reference to the ro_crate report for this Data product
+   */
+  public APIURL getRo_crate() {
+    return this.ro_crate;
   }
 
   /** @param run_date Datetime of the CodeRun. */

--- a/dataregistry/src/main/java/org/fairdatapipeline/dataregistry/content/RegistryData_product.java
+++ b/dataregistry/src/main/java/org/fairdatapipeline/dataregistry/content/RegistryData_product.java
@@ -26,6 +26,8 @@ public class RegistryData_product extends Registry_Updateable {
 
   @XmlElement private APIURL prov_report;
 
+  @XmlElement private APIURL ro_crate;
+
   /** Empty constructor. */
   public RegistryData_product() {
     this.methods_allowed = List.of("GET", "PUT", "PATCH", "HEAD", "OPTIONS");
@@ -93,6 +95,15 @@ public class RegistryData_product extends Registry_Updateable {
    */
   public APIURL getProv_report() {
     return this.prov_report;
+  }
+
+  /**
+   * APIURL reference to the ro_crate for this Data product
+   *
+   * @return APIURL reference to the ro_crate report for this Data product
+   */
+  public APIURL getRo_crate() {
+    return this.ro_crate;
   }
 
   /**


### PR DESCRIPTION
The ro_crate implementation of the data registry adds a new field: `ro_crate` that needs to be allowed in `code_run`s and `data_product`s.